### PR TITLE
chore: gitignore local PENDING-i18n.md notes file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ replit.nix
 .env
 .env.*
 !.env.example
+
+# Local notes (not tracked)
+PENDING-i18n.md


### PR DESCRIPTION
Adds `PENDING-i18n.md` to `.gitignore` so the local i18n follow-up notes file stays out of version control.

The notes file itself is intentionally **not** committed (kept local). This PR only persists the ignore rule.

https://claude.ai/code/session_011SxJRyEKcaGubV1LUjkU2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_011SxJRyEKcaGubV1LUjkU2Y)_